### PR TITLE
Correctly handle query values

### DIFF
--- a/excon-addressable.gemspec
+++ b/excon-addressable.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
-  spec.add_development_dependency 'rubocop', '~> 0.40'
+  spec.add_development_dependency 'rubocop', '~> 0.40.0'
   spec.add_development_dependency 'pry', '~> 0.10'
 
   spec.add_dependency 'excon', '~> 0.49'

--- a/lib/excon/addressable.rb
+++ b/lib/excon/addressable.rb
@@ -15,6 +15,11 @@ module Excon
     #
     class Middleware < Excon::Middleware::Base
       def request_call(datum)
+        # we need to convert a query hash (or string) to the proper format for
+        # Addressable to work with. We also need to remove the `?` character
+        # that Excon prepends to the final query string.
+        datum[:query] = Excon::Utils.query_string(datum)[1..-1]
+
         url = ::Addressable::URI.new(datum)
 
         if (template = ::Addressable::Template.new(url)) && template.variables.any?

--- a/test/excon/addressable_test.rb
+++ b/test/excon/addressable_test.rb
@@ -13,6 +13,7 @@ module Excon
       Excon.stub({ path: '/' }, body: 'index')
       Excon.stub({ path: '/hello' }, body: 'world')
       Excon.stub({ path: '/hello', query: 'message=world' }, body: 'hi!')
+      Excon.stub({ path: '/hello', query: 'a=b&c=d' }, body: 'earth')
       Excon.stub({ path: '/world' }, body: 'universe')
     end
 
@@ -48,6 +49,24 @@ module Excon
       response   = connection.get(expand: { uid: 'hello', message: 'world' })
 
       assert_equal 'hi!', response.body
+    end
+
+    def test_uri_with_full_uri
+      response = Excon.get('http://www.example.com/hello?message=world')
+
+      assert_equal 'hi!', response.body
+    end
+
+    def test_uri_with_query
+      response = Excon.get('http://www.example.com/hello', query: { message: 'world' })
+
+      assert_equal 'hi!', response.body
+    end
+
+    def test_uri_with_multiple_queries
+      response = Excon.get('https://www.example.com/hello', query: { a: 'b', c: 'd' })
+
+      assert_equal 'earth', response.body
     end
 
     def teardown


### PR DESCRIPTION
This was broken because Addressable does not like hashed query params, and instead expects the raw `a=b&c=d` string.

We could also set `query` to [`query_values`](https://github.com/sporkmonger/addressable/blob/0e640ca64ab461d43bcf0d5515adc8f63da76872/lib/addressable/uri.rb#L1656-L1674) if it's a hash, but this will work as well.