### PR TITLE
Make sure Excon can access all parser methods

### DIFF
--- a/excon-addressable.gemspec
+++ b/excon-addressable.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'excon/addressable/version'
 

--- a/lib/excon/addressable/parser.rb
+++ b/lib/excon/addressable/parser.rb
@@ -9,9 +9,9 @@ module Excon
     # @see : https://github.com/excon/excon/issues/384#issuecomment-42645517
     # @see : https://github.com/excon/excon/issues/384#issuecomment-362618298
     #
-    class Parser
+    class Parser < ::Addressable::URI
       def self.parse(url)
-        uri = ::Addressable::URI.parse(url)
+        uri = super
         uri.port = uri.inferred_port unless uri.port
         uri
       end

--- a/test/excon/addressable_test.rb
+++ b/test/excon/addressable_test.rb
@@ -16,8 +16,8 @@ module Excon
       Excon.stub({ path: '/hello', query: 'message=world' }, body: 'hi!')
       Excon.stub({ path: '/hello', query: 'a=b&c=d' }, body: 'earth')
       Excon.stub({ path: '/world' }, body: 'universe')
-      Excon.stub({ path: '/foo' }, { headers: { 'Location' => '/bar' }, body: 'no', status: 301 })
-      Excon.stub({ path: '/bar' }, { body: 'ok!', status: 200 })
+      Excon.stub({ path: '/foo' }, headers: { 'Location' => '/bar' }, body: 'no', status: 301)
+      Excon.stub({ path: '/bar' }, body: 'ok!', status: 200)
     end
 
     def test_expand_templated_uri

--- a/test/excon/addressable_test.rb
+++ b/test/excon/addressable_test.rb
@@ -16,6 +16,8 @@ module Excon
       Excon.stub({ path: '/hello', query: 'message=world' }, body: 'hi!')
       Excon.stub({ path: '/hello', query: 'a=b&c=d' }, body: 'earth')
       Excon.stub({ path: '/world' }, body: 'universe')
+      Excon.stub({ path: '/foo' }, { headers: { 'Location' => '/bar' }, body: 'no', status: 301 })
+      Excon.stub({ path: '/bar' }, { body: 'ok!', status: 200 })
     end
 
     def test_expand_templated_uri
@@ -68,6 +70,15 @@ module Excon
       response = Excon.get('https://www.example.com/hello', query: { a: 'b', c: 'd' })
 
       assert_equal 'earth', response.body
+    end
+
+    def test_uri_with_redirect
+      response = Excon.get(
+        'https://www.example.com/foo',
+        middlewares: Excon.defaults[:middlewares] + [Excon::Middleware::RedirectFollower]
+      )
+
+      assert_equal 'ok!', response.body
     end
 
     def teardown

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'excon/addressable'
 require 'minitest/autorun'


### PR DESCRIPTION
Fixes Excon `>= v0.61.0` integration. See [here](https://github.com/excon/excon/commit/bba25d07da143446a28196dccbfe0e3c453affe6).